### PR TITLE
Provide a default export

### DIFF
--- a/lib/neodoc.js
+++ b/lib/neodoc.js
@@ -8,3 +8,5 @@ export function run(spec, opts) {
 export function parse(...args) {
   return docopt.parseHelpTextJS(...args)();
 }
+
+export default { run, parse };


### PR DESCRIPTION
That way users can write:

``` js
import neodoc from 'neodoc';
```

instead of:

``` js
import * as neodoc from 'neodoc';
```
